### PR TITLE
Adding new search path for nvidia-p2p.h

### DIFF
--- a/ajadriver/linux/Makefile
+++ b/ajadriver/linux/Makefile
@@ -28,7 +28,7 @@ endif
 
 ifdef AJA_RDMA
 ifeq ($(NVIDIA_SRC_DIR),)
-	NVIDIA_SRC_DIR := $(shell find /usr/src/nvidia-* -name nv-p2p.h 2>/dev/null|head -1|xargs dirname 2>/dev/null)
+	NVIDIA_SRC_DIR := $(shell find /usr/src/nvidia* -name nv-p2p.h 2>/dev/null|head -1|xargs dirname 2>/dev/null)
 endif
 ifeq ($(NVIDIA_SRC_DIR),)
 	NVIDIA_SRC_DIR := $(shell find /usr/src/linux-* -name nv-p2p.h 2>/dev/null|head -1|xargs dirname 2>/dev/null)


### PR DESCRIPTION
nvidia-p2p.h is located in /usr/src/nvidia/nvidia-oot/include/linux on newer (6.2+) version of L4T